### PR TITLE
Move tenant onboarding form to modal

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,54 +1,38 @@
-import { TenantOnboardingForm } from "@/components/tenant-onboarding-form"
 import { RecentActivities } from "@/components/recent-activities"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
 export default function HomePage() {
   return (
       <div className="flex-1 space-y-6 p-6">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Tenant Onboarding</h1>
-          <p className="text-muted-foreground">Manage and configure new tenant setups</p>
+          <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
+          <p className="text-muted-foreground">Overview of tenant activities and stats</p>
         </div>
 
-        <div className="grid gap-6">
-          {/* First row: Onboarding form and Quick stats side by side */}
-          <div className="grid gap-6 lg:grid-cols-3">
-            <div className="lg:col-span-2">
-              <Card>
-                <CardHeader>
-                  <CardTitle>New Tenant Setup</CardTitle>
-                  <CardDescription>Complete the onboarding process for a new tenant</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <TenantOnboardingForm />
-                </CardContent>
-              </Card>
-            </div>
-
-            <div>
-              <Card>
-                <CardHeader>
-                  <CardTitle>Quick Stats</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="flex justify-between">
-                    <span className="text-sm text-muted-foreground">Active Tenants</span>
-                    <span className="font-medium">24</span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-sm text-muted-foreground">Pending Onboarding</span>
-                    <span className="font-medium">3</span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-sm text-muted-foreground">This Month</span>
-                    <span className="font-medium">8</span>
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
+        <div className="grid gap-6 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <RecentActivities />
           </div>
           <div>
-            <RecentActivities />
+            <Card>
+              <CardHeader>
+                <CardTitle>Quick Stats</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex justify-between">
+                  <span className="text-sm text-muted-foreground">Active Tenants</span>
+                  <span className="font-medium">24</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-sm text-muted-foreground">Pending Onboarding</span>
+                  <span className="font-medium">3</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-sm text-muted-foreground">This Month</span>
+                  <span className="font-medium">8</span>
+                </div>
+              </CardContent>
+            </Card>
           </div>
         </div>
       </div>

--- a/app/tenants/page.tsx
+++ b/app/tenants/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -12,11 +12,13 @@ import { useAppDispatch, useAppSelector } from "@/lib/hooks/redux-hooks"
 import { fetchTenants, setFilters } from "@/lib/features/tenant/tenant-slice"
 import { Search, Building2, Mail, User, Tag, MoreHorizontal, Edit, Trash2, UserPlus } from "lucide-react"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { TenantCreationModal } from "@/components/tenant-creation-modal"
 
 export default function TenantsPage() {
   const dispatch = useAppDispatch()
   const router = useRouter()
   const { tenants, loading, error, filters } = useAppSelector((state) => state.tenant)
+  const [isModalOpen, setIsModalOpen] = useState(false)
 
   useEffect(() => {
     dispatch(fetchTenants(filters))
@@ -53,7 +55,7 @@ export default function TenantsPage() {
   }
 
   const handleAddTenant = () => {
-    router.push("/")
+    setIsModalOpen(true)
   }
 
   if (loading) {
@@ -297,6 +299,8 @@ export default function TenantsPage() {
             </CardContent>
           </Card>
         )}
+        {/* Tenant Creation Modal */}
+        <TenantCreationModal open={isModalOpen} onOpenChange={setIsModalOpen} />
       </div>
   )
 }

--- a/components/tenant-creation-modal.tsx
+++ b/components/tenant-creation-modal.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { TenantOnboardingForm } from "@/components/tenant-onboarding-form"
+
+interface TenantCreationModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function TenantCreationModal({ open, onOpenChange }: TenantCreationModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[700px] max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-semibold">Create New Tenant</DialogTitle>
+          <DialogDescription>
+            Fill in the information below to onboard a new tenant.
+          </DialogDescription>
+        </DialogHeader>
+        <TenantOnboardingForm />
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- create `TenantCreationModal` to host the tenant onboarding form
- remove the form from the dashboard page
- launch modal from tenants list page

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6864bf9563ac8324a2652c3f8b308b05