### PR TITLE
Move tenant onboarding form to modal

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,54 +1,100 @@
-import { TenantOnboardingForm } from "@/components/tenant-onboarding-form"
-import { RecentActivities } from "@/components/recent-activities"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+"use client"
+
+import { useEffect, useMemo } from "react"
+import { RecentActivities, type Activity } from "@/components/recent-activities"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useAppDispatch, useAppSelector } from "@/lib/hooks/redux-hooks"
+import { fetchTenants } from "@/lib/features/tenant/tenant-slice"
+import { fetchUsers } from "@/lib/features/user/user-slice"
+import { Building2, Clock, CalendarDays, User } from "lucide-react"
 
 export default function HomePage() {
+  const dispatch = useAppDispatch()
+  const { tenants } = useAppSelector((state) => state.tenant)
+  const { users } = useAppSelector((state) => state.user)
+
+  useEffect(() => {
+    dispatch(fetchTenants())
+    dispatch(fetchUsers())
+  }, [dispatch])
+
+  const activeTenants = tenants.filter((t) => t.status === "active").length
+  const pendingTenants = tenants.filter((t) => t.status === "pending").length
+  const tenantsThisMonth = tenants.filter((t) => {
+    const created = new Date(t.createdAt)
+    const now = new Date()
+    return (
+      created.getMonth() === now.getMonth() &&
+      created.getFullYear() === now.getFullYear()
+    )
+  }).length
+
+  const activities: Activity[] = useMemo(() => {
+    const tenantActs = tenants.map((t) => ({
+      id: `tenant-${t.id}`,
+      type: "tenant_created",
+      title: `Tenant created: ${t.tenant_name}`,
+      description: t.tenant_description,
+      timestamp: t.createdAt,
+      status: "completed",
+      icon: Building2,
+      user: `${t.first_name} ${t.last_name}`,
+    }))
+    const userActs = users.map((u) => ({
+      id: `user-${u.id}`,
+      type: "user_created",
+      title: `User created: ${u.first_name} ${u.last_name}`,
+      description: u.email,
+      timestamp: u.createdAt,
+      status: "completed",
+      icon: User,
+      user: `${u.first_name} ${u.last_name}`,
+    }))
+    return [...tenantActs, ...userActs].sort(
+      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+    )
+  }, [tenants, users])
+
   return (
       <div className="flex-1 space-y-6 p-6">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Tenant Onboarding</h1>
-          <p className="text-muted-foreground">Manage and configure new tenant setups</p>
+          <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
+          <p className="text-muted-foreground">Overview of tenant activities and stats</p>
         </div>
 
-        <div className="grid gap-6">
-          {/* First row: Onboarding form and Quick stats side by side */}
-          <div className="grid gap-6 lg:grid-cols-3">
-            <div className="lg:col-span-2">
-              <Card>
-                <CardHeader>
-                  <CardTitle>New Tenant Setup</CardTitle>
-                  <CardDescription>Complete the onboarding process for a new tenant</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <TenantOnboardingForm />
-                </CardContent>
-              </Card>
-            </div>
-
-            <div>
-              <Card>
-                <CardHeader>
-                  <CardTitle>Quick Stats</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="flex justify-between">
-                    <span className="text-sm text-muted-foreground">Active Tenants</span>
-                    <span className="font-medium">24</span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-sm text-muted-foreground">Pending Onboarding</span>
-                    <span className="font-medium">3</span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-sm text-muted-foreground">This Month</span>
-                    <span className="font-medium">8</span>
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
+        <div className="grid gap-6 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <RecentActivities activities={activities} limit={3} />
           </div>
           <div>
-            <RecentActivities />
+            <Card>
+              <CardHeader>
+                <CardTitle>Quick Stats</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex items-center justify-between p-3 bg-blue-50 dark:bg-blue-950/30 rounded-lg">
+                  <div className="flex items-center gap-2">
+                    <Building2 className="h-4 w-4 text-blue-600" />
+                    <span className="text-sm font-medium">Active Tenants</span>
+                  </div>
+                  <span className="text-lg font-bold text-blue-600">{activeTenants}</span>
+                </div>
+                <div className="flex items-center justify-between p-3 bg-yellow-50 dark:bg-yellow-950/30 rounded-lg">
+                  <div className="flex items-center gap-2">
+                    <Clock className="h-4 w-4 text-yellow-600" />
+                    <span className="text-sm font-medium">Pending Onboarding</span>
+                  </div>
+                  <span className="text-lg font-bold text-yellow-600">{pendingTenants}</span>
+                </div>
+                <div className="flex items-center justify-between p-3 bg-green-50 dark:bg-green-950/30 rounded-lg">
+                  <div className="flex items-center gap-2">
+                    <CalendarDays className="h-4 w-4 text-green-600" />
+                    <span className="text-sm font-medium">Created This Month</span>
+                  </div>
+                  <span className="text-lg font-bold text-green-600">{tenantsThisMonth}</span>
+                </div>
+              </CardContent>
+            </Card>
           </div>
         </div>
       </div>

--- a/app/tenants/page.tsx
+++ b/app/tenants/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -12,11 +12,13 @@ import { useAppDispatch, useAppSelector } from "@/lib/hooks/redux-hooks"
 import { fetchTenants, setFilters } from "@/lib/features/tenant/tenant-slice"
 import { Search, Building2, Mail, User, Tag, MoreHorizontal, Edit, Trash2, UserPlus } from "lucide-react"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { TenantCreationModal } from "@/components/tenant-creation-modal"
 
 export default function TenantsPage() {
   const dispatch = useAppDispatch()
   const router = useRouter()
   const { tenants, loading, error, filters } = useAppSelector((state) => state.tenant)
+  const [isModalOpen, setIsModalOpen] = useState(false)
 
   useEffect(() => {
     dispatch(fetchTenants(filters))
@@ -53,7 +55,7 @@ export default function TenantsPage() {
   }
 
   const handleAddTenant = () => {
-    router.push("/")
+    setIsModalOpen(true)
   }
 
   if (loading) {
@@ -297,6 +299,8 @@ export default function TenantsPage() {
             </CardContent>
           </Card>
         )}
+        {/* Tenant Creation Modal */}
+        <TenantCreationModal open={isModalOpen} onOpenChange={setIsModalOpen} />
       </div>
   )
 }

--- a/components/recent-activities.tsx
+++ b/components/recent-activities.tsx
@@ -3,7 +3,18 @@ import { Badge } from "@/components/ui/badge"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Building2, UserPlus, Settings, CheckCircle } from "lucide-react"
 
-const activities = [
+export interface Activity {
+  id: string
+  type: string
+  title: string
+  description: string
+  timestamp: string
+  status: string
+  icon: React.ComponentType<{ className?: string }>
+  user: string
+}
+
+const defaultActivities: Activity[] = [
   {
     id: 1,
     type: "tenant_created",
@@ -59,7 +70,13 @@ const getStatusColor = (status: string) => {
   }
 }
 
-export function RecentActivities() {
+interface RecentActivitiesProps {
+  activities?: Activity[]
+  limit?: number
+}
+
+export function RecentActivities({ activities = defaultActivities, limit = 4 }: RecentActivitiesProps) {
+  const data = activities.slice(0, limit)
   return (
     <Card>
       <CardHeader>
@@ -68,7 +85,7 @@ export function RecentActivities() {
       </CardHeader>
       <CardContent>
         <div className="space-y-4">
-          {activities.map((activity) => {
+          {data.map((activity) => {
             const IconComponent = activity.icon
             return (
               <div key={activity.id} className="flex items-start space-x-3">

--- a/components/tenant-creation-modal.tsx
+++ b/components/tenant-creation-modal.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { TenantOnboardingForm } from "@/components/tenant-onboarding-form"
+
+interface TenantCreationModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function TenantCreationModal({ open, onOpenChange }: TenantCreationModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[700px] max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-semibold">Create New Tenant</DialogTitle>
+          <DialogDescription>
+            Fill in the information below to onboard a new tenant.
+          </DialogDescription>
+        </DialogHeader>
+        <TenantOnboardingForm />
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- create `TenantCreationModal` to host the tenant onboarding form
- remove the form from the dashboard page
- launch modal from tenants list page
- use Redux store data on the dashboard for quick stats
- show only the latest three activities

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6864bf9563ac8324a2652c3f8b308b05